### PR TITLE
[Fix #6] Implement `#respond_to?` public method.

### DIFF
--- a/lib/wisper_subscription.rb
+++ b/lib/wisper_subscription.rb
@@ -21,6 +21,11 @@ class WisperSubscription
     @internals[message]
   end
 
+  def respond_to?(symbol, include_all = false)
+    return true if symbol.to_s =~ /^.*\?$/
+    super
+  end
+
   private
 
   attr_reader :empty_payload

--- a/spec/wisper_subscription_spec.rb
+++ b/spec/wisper_subscription_spec.rb
@@ -102,4 +102,18 @@ describe WisperSubscription do
       end
     end # describe 'returns the payload(s) received for the ... message when'
   end # describe '#payload_for'
+
+  describe '#respond_to?' do
+    it 'returns true for any query method' do
+      expect(obj).to respond_to :is_that_right?
+      expect(obj).to respond_to :you_dont_say?
+      expect(obj).to respond_to :all_tone_here?
+    end
+
+    it 'returns false for any other undefined method' do
+      expect(obj).not_to respond_to :taunts
+      expect(obj).not_to respond_to :threats
+      expect(obj).not_to respond_to :anything
+    end
+  end # describe '#respond_to?'
 end


### PR DESCRIPTION
Next up: `#method_missing`.

RSpec: 17 examples, 0 failures
RuboCop: 4 files inspected, no offences detected
