### PR TITLE
[Fix #8] Implement `#method_missing`.

### DIFF
--- a/lib/wisper_subscription.rb
+++ b/lib/wisper_subscription.rb
@@ -6,6 +6,7 @@ class WisperSubscription
   def initialize
     @internals = {}
     @empty_payload = []
+    @query_pattern = /^.*\?$/
   end
 
   def define_message(message)
@@ -21,14 +22,19 @@ class WisperSubscription
     @internals[message]
   end
 
+  def method_missing(method_sym, *arguments, &block)
+    return false if method_sym.to_s =~ query_pattern
+    super
+  end
+
   def respond_to?(symbol, include_all = false)
-    return true if symbol.to_s =~ /^.*\?$/
+    return true if symbol.to_s =~ query_pattern
     super
   end
 
   private
 
-  attr_reader :empty_payload
+  attr_reader :empty_payload, :query_pattern
 
   def add_internals_entry
     @internals[@message.to_sym] = []
@@ -38,7 +44,7 @@ class WisperSubscription
   def add_query_method
     message = @message
     define_singleton_method "#{@message}?".to_sym do
-      @internals[message].to_a.empty?
+      !@internals[message].to_a.empty?
     end
     self
   end

--- a/spec/wisper_subscription_spec.rb
+++ b/spec/wisper_subscription_spec.rb
@@ -116,4 +116,17 @@ describe WisperSubscription do
       expect(obj).not_to respond_to :anything
     end
   end # describe '#respond_to?'
+
+  describe '.method_missing' do
+    it 'causes an unknown query method to return false' do
+      expect(obj).not_to be_success
+      expect(obj).not_to be_real
+      expect(obj).not_to be_anything_in_particular
+    end
+
+    it 'raises a NoMethodError for any other undefined method' do
+      message = Regexp.new 'undefined method `bogus\' for'
+      expect { obj.bogus }.to raise_error NoMethodError, message
+    end
+  end # describe '.method_missing'
 end

--- a/wisper_subscription.gemspec
+++ b/wisper_subscription.gemspec
@@ -23,6 +23,9 @@ Gem::Specification.new do |spec|
 
   spec.add_development_dependency 'rubocop', '>= 0.28.0'
   spec.add_development_dependency 'simplecov', '>= 0.9.1'
+  spec.add_development_dependency 'awesome_print'
+  spec.add_development_dependency 'pry-byebug'
+  spec.add_development_dependency 'pry-doc'
 
   spec.description   = %q{May be used to subscribe to Wisper broadcasts, or other
 similar mechanisms. Define what messages you want an instance to respond to and,


### PR DESCRIPTION
Per Issue #8, returns false for an undeclared query method, raises a
NoMethodError otherwise.

Also corrected the polarity on the query method. :flushed:

RSpec: 19 examples, 0 failures
RuboCop: 4 files inspected, no offences detected
